### PR TITLE
[Lib] Add steps to configure host details

### DIFF
--- a/playbooks/provision_nodes.yaml
+++ b/playbooks/provision_nodes.yaml
@@ -200,3 +200,89 @@
     register: async_poll_results
     until: async_poll_results.finished
     retries: "{{ 6 * 100 }}"
+
+  - name: Read info of newly created VMs
+    vmware_guest_tools_wait:
+      hostname: "{{ vcenter_host }}"
+      username: "{{ vcenter_username }}"
+      password: "{{ vcenter_password }}"
+      folder: "/{{ vcenter_folder }}"
+      validate_certs: False
+      uuid: "{{ item.instance.hw_product_uuid }}"
+    with_items: "{{ async_poll_results.results }}"
+    register: facts
+
+  - name: Map node names and their IP addresses
+    set_fact:
+      hostnames_ip_mapping: "{{ hostnames_ip_mapping | default({}) | combine(
+        {item.instance.hw_name: item.instance.hw_eth0.ipaddresses|ipv4|first},
+        recursive=True
+      ) }}"
+    with_items: "{{ facts.results }}"
+
+  - name: Update routing on the localhost
+    import_role:
+      name: add-routing-info-to-etc-hosts
+    vars:
+      hostnames_ip_mapping: "{{ hostnames_ip_mapping }}"
+
+  # Add references to the just provisioned VMs
+  - name: Add grafana_server nodes if not added yet
+    add_host:
+      name: "{{ item }}"
+      groups: dt_grafana_server
+      ansible_user: root
+    with_items: "{{ config.vcenter.vm_parameters.grafana_server.names }}"
+    when:
+    - "'dt_grafana_server' not in groups"
+  - name: Add mon nodes if not added yet
+    add_host:
+      name: "{{ item }}"
+      groups: dt_mon
+      ansible_user: root
+    with_items: "{{ config.vcenter.vm_parameters.mon.names }}"
+    when:
+    - "'dt_mon' not in groups"
+  - name: Add osds nodes if not added yet
+    add_host:
+      name: "{{ item }}"
+      groups: dt_osds
+      ansible_user: root
+    with_items: "{{ config.vcenter.vm_parameters.osds.names }}"
+    when:
+    - "'dt_osds' not in groups"
+  - name: Add mgrs nodes if not added yet
+    add_host:
+      name: "{{ item }}"
+      groups: dt_mgrs
+      ansible_user: root
+    with_items: "{{ config.vcenter.vm_parameters.mgrs.names }}"
+    when:
+    - "'dt_mgrs' not in groups"
+  - name: Add client nodes if not added yet
+    add_host:
+      name: "{{ item }}"
+      groups: dt_client
+      ansible_user: root
+    with_items: "{{ config.vcenter.vm_parameters.client.names }}"
+    when:
+    - "'dt_client' not in groups"
+
+  - name: Wait for SSH availability of newly provisioned VMs
+    wait_for:
+      host: "{{ item.value }}"
+      port: 22
+      delay: 0
+      timeout: 420
+      connect_timeout: 5
+      state: started
+    with_dict: "{{ hostnames_ip_mapping }}"
+
+- name: Update all the Ceph nodes with routing info about each other
+  hosts: dt_grafana_server, dt_mon, dt_osds, dt_mgrs, dt_client
+  gather_facts: no
+  roles:
+  - add-routing-info-to-etc-hosts
+  - extend-root-volume
+  vars:
+    hostnames_ip_mapping: "{{ hostvars['localhost'].hostnames_ip_mapping }}"

--- a/playbooks/roles/add-routing-info-to-etc-hosts/tasks/main.yaml
+++ b/playbooks/roles/add-routing-info-to-etc-hosts/tasks/main.yaml
@@ -1,0 +1,23 @@
+#  Expected vars:
+#
+#  - 'hostnames_ip_mapping' - required. Should be dict, where
+#    keys are hostnames and values are IP addresses.
+---
+- name: Delete old left-overs if exist
+  become: yes
+  become_user: root
+  lineinfile:
+    dest: "/etc/hosts"
+    regexp: '{{ item.key }}'
+    state: absent
+    create: true
+  with_dict: "{{ hostnames_ip_mapping }}"
+
+- name: Add domain name mapping of new cluster nodes to the system hosts file
+  become: yes
+  become_user: root
+  lineinfile:
+    dest: "/etc/hosts"
+    line: "{{ item.value }} {{ item.key }}"
+    create: true
+  with_dict: "{{ hostnames_ip_mapping }}"

--- a/playbooks/roles/extend-root-volume/tasks/main.yaml
+++ b/playbooks/roles/extend-root-volume/tasks/main.yaml
@@ -1,0 +1,72 @@
+# No vars are expected to be provided
+---
+- name: Get VG name for 'root' LV
+  shell: "lvs | grep -v 'tp_' | grep -v 'brick_' | grep ' root ' | awk '{print $2}'"
+  register: vg_raw
+
+- name: Get PV name(s) for VG
+  shell: "pvs | grep -e '{{ vg_raw.stdout.strip() }}' | awk '{print $1}'"
+  register: pvs_raw
+
+- name: Get partition information
+  parted:
+    device: "{{ pvs_raw.stdout.split('\n')[-1].strip()[:-1] }}"
+  register: partinfo
+
+- name: DEBUG. Print info about the disk and it's partitions used for root dir
+  debug:
+    msg: "{{ partinfo }}"
+
+- name: Calculate summary partitions size
+  set_fact:
+    dt_partinions_summary_size_gb: "{{
+      (dt_partinions_summary_size_gb | default(0) | int) + (item.size | int)}}"
+  with_items: "{{ partinfo.partitions }}"
+
+- name: Calculate unallocated disk size
+  set_fact:
+    dt_unallocated_disk_space_gb: "{{
+      (((partinfo.disk.size | int) - (dt_partinions_summary_size_gb | int)) /
+        1024**2) | int }}"
+
+- name: DEBUG. Print unallocated disk space calculated in Gb
+  debug:
+    var: dt_unallocated_disk_space_gb
+
+- block:
+  - name: Create new partition which will be used for extending the root VG
+    parted:
+      part_start: "{{ partinfo.partitions[1].end }}KiB"
+      device: "{{ partinfo.disk.dev }}"
+      number: "{{ partinfo.partitions[-1].num + 1 }}"
+      flags: [lvm]
+      state: present
+
+  - name: Probe kernel about partition table changes
+    command: partprobe
+
+  - name: Extend volume group
+    lvg:
+      vg: "{{ vg_raw.stdout.strip() }}"
+      pvs: "{{ partinfo.disk.dev }}{{
+               partinfo.partitions[-1].num }},{{ partinfo.disk.dev }}{{
+               partinfo.partitions[-1].num + 1 }}"
+
+  - name: Extend the root logical volume
+    lvol:
+      vg: "{{ vg_raw.stdout.strip() }}"
+      lv: "root"
+      size: "+100%FREE"
+      shrink: no
+
+  # Following is required for Ansible 2.4-
+  - name: Get fstype of the root dir and device mapper name instance
+    shell: "mount | grep '\\/ '"
+    register: root_mount_raw
+
+  - name: Extend the root filesystem
+    filesystem:
+      fstype: "{{ root_mount_raw.stdout.strip().split(' ')[4] }}"
+      dev: "{{ root_mount_raw.stdout.strip().split(' ')[0] }}"
+      resizefs: yes
+  when: "(dt_unallocated_disk_space_gb | int) > 2"

--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,14 @@ commands =
     python -m pip install --upgrade pip>=9.0.0
     pip install \
         schema \
-        pyvmomi
+        pyvmomi \
+        netaddr
+    bash -ec "yum -y install libselinux-python || echo 'WARNING! Failed to run yum command. Make sure you have enough rights. Continuing assuming that yum packages are installed.'"
+    mkdir -p {envdir}/lib/python2.7/site-packages
+    bash -ec "if [ ! -e {envdir}/lib/python2.7/site-packages/selinux ]; then \
+        ln -s /usr/lib64/python2.7/site-packages/selinux \
+        {envdir}/lib/python2.7/site-packages/selinux ; \
+    fi"
     find . -type f -name "*.py[c|o]" -delete
 
 [testenv:readme]


### PR DESCRIPTION
Add support in `playbooks/provision_nodes.yaml` to add host configs on deployed vms. It includes -

- add-routing-info-to-etc-hosts - Ansible role to add routing into into `/etc/hosts`
- extend-root-volume - Ansible role to configure root disk
- tox.ini - Packages required for ansible roles